### PR TITLE
Implement index test for sequential test and setting testcontainer once

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "handler.js",
   "scripts": {
-    "test": "jest" 
+    "test": "jest index.test.js" 
   },
   "keywords": [],
   "author": "",

--- a/test/getParts.test.js
+++ b/test/getParts.test.js
@@ -15,71 +15,73 @@ const mysql = require("serverless-mysql")({
 
 const getParts = require("../src/getParts");
 
-describe("getParts", () => {
-  beforeAll(async () => {
-    // Given
-    let expectedTables = ["subject", "course", "chapter", "part"];
-    await createTables(expectedTables);
-    await insertGivenData(expectedTables);
-  }, 30000);
+const getPartsTest = () => {
+  describe("getParts", () => {
+    beforeAll(async () => {
+      // Given
+      let expectedTables = ["subject", "course", "chapter", "part"];
+      await createTables(expectedTables);
+      await insertGivenData(expectedTables);
+    }, 30000);
 
-  test("When course_id is not in the queryString", () => {
-    const event = lambdaEventMock
-      .apiGateway()
-      .path("/parts")
-      .method("GET")
-      .queryStringParameters({ courseId: 3 })
-      .build();
+    test("When course_id is not in the queryString", () => {
+      const event = lambdaEventMock
+        .apiGateway()
+        .path("/parts")
+        .method("GET")
+        .queryStringParameters({ courseId: 3 })
+        .build();
 
-    return getParts.handler(event).then((result) => {
-      // Then
-      expect(result.statusCode).toBe(400);
-      expect(result.body).toEqual(
-        JSON.stringify({
-          message: "there is no matching queryString",
-        })
-      );
+      return getParts.handler(event).then((result) => {
+        // Then
+        expect(result.statusCode).toBe(400);
+        expect(result.body).toEqual(
+          JSON.stringify({
+            message: "there is no matching queryString",
+          })
+        );
+      });
     });
-  });
 
-  test("When there isn't any parts corresponding to course_id", () => {
-    const event = lambdaEventMock
-      .apiGateway()
-      .path("/parts")
-      .method("GET")
-      .queryStringParameters({ course_id: 3 })
-      .build();
+    test("When there isn't any parts corresponding to course_id", () => {
+      const event = lambdaEventMock
+        .apiGateway()
+        .path("/parts")
+        .method("GET")
+        .queryStringParameters({ course_id: 3 })
+        .build();
 
-    return getParts.handler(event).then((result) => {
-      // Then
-      expect(result.statusCode).toBe(404);
-      expect(result.body).toEqual(
-        JSON.stringify({
-          message: "해당하는 과목 정보가 없습니다.",
-        })
-      );
+      return getParts.handler(event).then((result) => {
+        // Then
+        expect(result.statusCode).toBe(404);
+        expect(result.body).toEqual(
+          JSON.stringify({
+            message: "해당하는 과목 정보가 없습니다.",
+          })
+        );
+      });
     });
-  });
 
-  test("When there are some parts corresponding to course_id", () => {
-    const event = lambdaEventMock
-      .apiGateway()
-      .path("/parts")
-      .method("GET")
-      .queryStringParameters({ course_id: 7 })
-      .build();
+    test("When there are some parts corresponding to course_id", () => {
+      const event = lambdaEventMock
+        .apiGateway()
+        .path("/parts")
+        .method("GET")
+        .queryStringParameters({ course_id: 7 })
+        .build();
 
-    return getParts.handler(event).then((result) => {
-      // Then
-      expect(result.statusCode).toBe(200);
-      expect(result.body).toEqual(JSON.stringify({}));
+      return getParts.handler(event).then((result) => {
+        // Then
+        expect(result.statusCode).toBe(200);
+        expect(result.body).toEqual(JSON.stringify({}));
+      });
     });
-  });
 
-  afterAll(async () => {
-    await mysql.end();
-  }, 20000);
-});
+    afterAll(async () => {
+      await mysql.end();
+    }, 20000);
+  });
+};
 
 async function createTables(tables) {
   const sqlPath = path.join(__dirname, "../sql/src");
@@ -108,3 +110,5 @@ async function insertGivenData(tables) {
   mysql.config({ multipleStatements: false });
   mysql.end();
 }
+
+module.exports = getPartsTest;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,8 @@
 const path = require("path");
 const { DockerComposeEnvironment } = require("testcontainers");
 
+const getPartsTest = require("./getParts.test");
+
 let environment;
 
 beforeAll(async () => {
@@ -8,8 +10,10 @@ beforeAll(async () => {
     path.join(__dirname, "../"),
     "docker-compose.yml"
   ).up();
-});
+}, 30000);
 
 afterAll(async () => {
   await environment.down();
 }, 20000);
+
+getPartsTest();


### PR DESCRIPTION
If there are some test files, Jest run test files in parallel.
It can be solved by add CLI keyword `--runInBand`.

However, if I solved this problem that way, the testcontainer up and down so many times as same as the number of tests.
I think that the testcontainer should be up once during whole test.
So, I implement index test which contains invoking and removing testcontainer and testing the test functions sequentially.