### PR TITLE
Implement index test for sequential test and setting testcontainer once 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "handler.js",
   "scripts": {
-    "test": "jest" 
+    "test": "jest index.test.js" 
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "handler.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest" 
   },
   "keywords": [],
   "author": "",

--- a/test/getParts.test.js
+++ b/test/getParts.test.js
@@ -1,6 +1,5 @@
 const { expect, test, beforeAll, afterAll } = require("@jest/globals");
 const lambdaEventMock = require("lambda-event-mock");
-const path = require("path");
 const { mysql, createTables, insertGivenData } = require("./lib/mysql");
 
 const getParts = require("../src/getParts");

--- a/test/getParts.test.js
+++ b/test/getParts.test.js
@@ -6,8 +6,6 @@ const { mysql, createTables, insertGivenData } = require("./lib/mysql");
 const getParts = require("../src/getParts");
 
 describe("getParts", () => {
-  let environment;
-
   beforeAll(async () => {
     // Given
     let expectedTables = ["subject", "course", "chapter", "part"];

--- a/test/getParts.test.js
+++ b/test/getParts.test.js
@@ -5,68 +5,72 @@ const { mysql, createTables, insertGivenData } = require("./lib/mysql");
 
 const getParts = require("../src/getParts");
 
-describe("getParts", () => {
-  beforeAll(async () => {
-    // Given
-    let expectedTables = ["subject", "course", "chapter", "part"];
-    await createTables(expectedTables);
-    await insertGivenData(expectedTables);
-  }, 30000);
+const getPartsTest = () => {
+  describe("getParts", () => {
+    beforeAll(async () => {
+      // Given
+      let expectedTables = ["subject", "course", "chapter", "part"];
+      await createTables(expectedTables);
+      await insertGivenData(expectedTables);
+    }, 30000);
 
-  test("When course_id is not in the queryString", () => {
-    const event = lambdaEventMock
-      .apiGateway()
-      .path("/parts")
-      .method("GET")
-      .queryStringParameters({ courseId: 3 })
-      .build();
+    test("When course_id is not in the queryString", () => {
+      const event = lambdaEventMock
+        .apiGateway()
+        .path("/parts")
+        .method("GET")
+        .queryStringParameters({ courseId: 3 })
+        .build();
 
-    return getParts.handler(event).then((result) => {
-      // Then
-      expect(result.statusCode).toBe(400);
-      expect(result.body).toEqual(
-        JSON.stringify({
-          message: "there is no matching queryString",
-        })
-      );
+      return getParts.handler(event).then((result) => {
+        // Then
+        expect(result.statusCode).toBe(400);
+        expect(result.body).toEqual(
+          JSON.stringify({
+            message: "there is no matching queryString",
+          })
+        );
+      });
     });
-  });
 
-  test("When there isn't any parts corresponding to course_id", () => {
-    const event = lambdaEventMock
-      .apiGateway()
-      .path("/parts")
-      .method("GET")
-      .queryStringParameters({ course_id: 3 })
-      .build();
+    test("When there isn't any parts corresponding to course_id", () => {
+      const event = lambdaEventMock
+        .apiGateway()
+        .path("/parts")
+        .method("GET")
+        .queryStringParameters({ course_id: 3 })
+        .build();
 
-    return getParts.handler(event).then((result) => {
-      // Then
-      expect(result.statusCode).toBe(404);
-      expect(result.body).toEqual(
-        JSON.stringify({
-          message: "해당하는 과목 정보가 없습니다.",
-        })
-      );
+      return getParts.handler(event).then((result) => {
+        // Then
+        expect(result.statusCode).toBe(404);
+        expect(result.body).toEqual(
+          JSON.stringify({
+            message: "해당하는 과목 정보가 없습니다.",
+          })
+        );
+      });
     });
-  });
 
-  test("When there are some parts corresponding to course_id", () => {
-    const event = lambdaEventMock
-      .apiGateway()
-      .path("/parts")
-      .method("GET")
-      .queryStringParameters({ course_id: 7 })
-      .build();
+    test("When there are some parts corresponding to course_id", () => {
+      const event = lambdaEventMock
+        .apiGateway()
+        .path("/parts")
+        .method("GET")
+        .queryStringParameters({ course_id: 7 })
+        .build();
 
-    return getParts.handler(event).then((result) => {
-      // Then
-      expect(result.statusCode).toBe(200);
-      expect(result.body).toEqual(JSON.stringify({}));
+      return getParts.handler(event).then((result) => {
+        // Then
+        expect(result.statusCode).toBe(200);
+        expect(result.body).toEqual(JSON.stringify({}));
+      });
     });
-  });
 
-  afterAll(async () => {
-    await mysql.end();
-  }, 20000);
-});
+    afterAll(async () => {
+      await mysql.end();
+    }, 20000);
+  });
+};
+
+module.exports = getPartsTest;

--- a/test/getParts.test.js
+++ b/test/getParts.test.js
@@ -1,7 +1,6 @@
 const { expect, test, beforeAll, afterAll } = require("@jest/globals");
 const lambdaEventMock = require("lambda-event-mock");
 const path = require("path");
-const { DockerComposeEnvironment } = require("testcontainers");
 const { mysql, createTables, insertGivenData } = require("./lib/mysql");
 
 const getParts = require("../src/getParts");
@@ -10,11 +9,6 @@ describe("getParts", () => {
   let environment;
 
   beforeAll(async () => {
-    environment = await new DockerComposeEnvironment(
-      path.join(__dirname, "../"),
-      "docker-compose.yml"
-    ).up();
-
     // Given
     let expectedTables = ["subject", "course", "chapter", "part"];
     await createTables(expectedTables);
@@ -76,6 +70,5 @@ describe("getParts", () => {
 
   afterAll(async () => {
     await mysql.end();
-    await environment.down();
   }, 20000);
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,8 @@
 const path = require("path");
 const { DockerComposeEnvironment } = require("testcontainers");
 
+const getPartsTest = require("./getParts.test");
+
 let environment;
 
 beforeAll(async () => {
@@ -8,8 +10,10 @@ beforeAll(async () => {
     path.join(__dirname, "../"),
     "docker-compose.yml"
   ).up();
-});
+}, 30000);
 
 afterAll(async () => {
   await environment.down();
 }, 20000);
+
+getPartsTest();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,15 @@
+const path = require("path");
+const { DockerComposeEnvironment } = require("testcontainers");
+
+let environment;
+
+beforeAll(async () => {
+  environment = await new DockerComposeEnvironment(
+    path.join(__dirname, "../"),
+    "docker-compose.yml"
+  ).up();
+});
+
+afterAll(async () => {
+  await environment.down();
+}, 20000);


### PR DESCRIPTION
If there are some test files, Jest run test files in parallel.
 It can be solved by add CLI keyword `—runInBand`.

However, if I solved this problem that way, the testcontainer up and down so many times as same as the number of tests. 
I think that the testcontainer should be up once during whole test. 
So, I implement index test which contains invoking and removing testcontainer and testing the test functions sequentially.
